### PR TITLE
Fix 'next page' button incorrect redirection when a language name includes a special symbol

### DIFF
--- a/app/language/[language]/[country]/[page]/page.tsx
+++ b/app/language/[language]/[country]/[page]/page.tsx
@@ -38,8 +38,8 @@ export default async function LanguageRanking({ params }: PageProps<'/language/[
         countries={countries}
       />
       <Pagination
-        prev={page > 1 ? `/language/${languageName}/${countryName}/${page - 1}` : undefined}
-        next={data?.length === ITEMS_PER_PAGE ? `/language/${languageName}/${countryName}/${page + 1}` : undefined}
+        prev={page > 1 ? `/language/${encodeURIComponent(languageName)}/${countryName}/${page - 1}` : undefined}
+        next={data?.length === ITEMS_PER_PAGE ? `/language/${encodeURIComponent(languageName)}/${countryName}/${page + 1}` : undefined}
       />
     </>
   );


### PR DESCRIPTION
I got `404` when viewed the `F# Language Ranking` page. Since `F#` in its name has `#`, it should be encoded into its own code align with proper URI standard.

Actual behavior: `https://gitranks.com/language/F%23/global/1` -> `https://gitranks.com/language/F#/global/2`
Expected behavior: `https://gitranks.com/language/F%23/global/1` -> `https://gitranks.com/language/F%23/global/2`